### PR TITLE
添加查询所有稿件状态的功能

### DIFF
--- a/crates/biliup/src/uploader/bilibili.rs
+++ b/crates/biliup/src/uploader/bilibili.rs
@@ -123,6 +123,35 @@ pub struct Studio {
     pub up_close_danmu: bool,
 }
 
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct Archive {
+    pub aid: u64,
+    pub bvid: String,
+    pub title: String,
+    pub cover: String,
+    pub reject_reason: String,
+    pub reject_reason_url: String,
+    pub duration: u64,
+    pub desc: String,
+    pub state: i16,
+    pub state_desc: String,
+    pub dtime: u64,
+    pub ptime: u64,
+    pub ctime: u64,
+}
+
+impl Archive {
+    pub fn to_string_pretty(&self) -> String {
+        let status_string = match self.state {
+            0 => format!("\x1b[1;92m{}\x1b[0m", self.state_desc),
+            -2 => format!("\x1b[1;91m{}\x1b[0m", self.state_desc),
+            -30 => format!("\x1b[1;93m{}\x1b[0m", self.state_desc),
+            _ => format!("{}", self.desc),
+        };
+        format!("{}\t{}\t{}", self.bvid, self.title, status_string)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Subtitle {
     open: i8,
@@ -342,6 +371,101 @@ impl BiliBili {
         } else {
             Err(Kind::Custom(format!("{res:?}")))
         }
+    }
+
+    /// 稿件管理
+    async fn archives(&self, status: &str, page_num: u32) -> Result<Value> {
+        let url_str = "https://member.bilibili.com/x/web/archives";
+        let params = [("status", status), ("pn", &page_num.to_string())];
+        let url = reqwest::Url::parse_with_params(url_str, &params).unwrap();
+
+        let cookie = self
+            .login_info
+            .cookie_info
+            .get("cookies")
+            .and_then(|c: &Value| c.as_array())
+            .ok_or("archives cookie error")?
+            .iter()
+            .filter_map(|c| match (c["name"].as_str(), c["value"].as_str()) {
+                (Some(name), Some(value)) => Some((name, value)),
+                _ => None,
+            })
+            .map(|c| format!("{}={}", c.0, c.1))
+            .collect::<Vec<_>>()
+            .join("; ");
+
+        let jar = reqwest::cookie::Jar::default();
+        jar.add_cookie_str(&cookie, &url);
+
+        let res: ResponseData = reqwest::Client::builder()
+            .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/63.0.3239.108")
+            .cookie_provider(std::sync::Arc::new(jar))
+            .timeout(Duration::new(60, 0))
+            .build()?
+            .get(url)
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        match res {
+            ResponseData {
+                code: _,
+                data: None,
+                ..
+            } => Err(Kind::Custom(format!("{:?}", res))),
+            ResponseData {
+                code: _,
+                data: Some(v),
+                ..
+            } => Ok(v),
+        }
+    }
+
+    /// 获取所有稿件原始数据
+    async fn all_archives_data(&self, status: &str) -> Result<Vec<Value>> {
+        let mut first_page = self.archives(status, 1).await?;
+
+        let (page_size, count) = {
+            let page = first_page["page"].take();
+            let page_size = page["ps"].as_u64().ok_or("all_studios ps error")?;
+            let count = page["count"].as_u64().ok_or("all_studios count error")?;
+            (page_size as u32, count as u32)
+        };
+
+        let pages = {
+            let mut pages = count / page_size;
+            if pages * page_size < count {
+                pages += 1;
+            }
+            pages
+        };
+
+        let mut all_pages = futures::future::try_join_all(
+            (2..=pages)
+                .map(|page_num| self.archives(status, page_num))
+                .collect::<Vec<_>>(),
+        )
+        .await?;
+        all_pages.insert(0, first_page);
+
+        Ok(all_pages)
+    }
+
+    /// 获取所有稿件
+    pub async fn all_archives(&self, status: &str) -> Result<Vec<Archive>> {
+        let studios = self
+            .all_archives_data(status)
+            .await?
+            .iter_mut()
+            .map(|page| page["arc_audits"].take())
+            .filter_map(|audits| serde_json::from_value::<Vec<Value>>(audits).ok())
+            .flat_map(|archives| archives.into_iter())
+            .map(|mut arc| arc["Archive"].take())
+            .filter_map(|studio| serde_json::from_value::<_>(studio).ok())
+            .collect::<Vec<_>>();
+
+        Ok(studios)
     }
 }
 

--- a/crates/bin/cli.rs
+++ b/crates/bin/cli.rs
@@ -110,6 +110,20 @@ pub enum Commands {
         #[arg(short, long, default_value = "19159")]
         port: u16,
     },
+    /// 列出所有已上传的视频
+    List {
+        /// 只包含进行中的视频
+        #[arg(long)]
+        is_pubing: bool,
+
+        /// 只包含已通过的视频
+        #[arg(long)]
+        pubed: bool,
+
+        /// 只包含未通过的视频
+        #[arg(long)]
+        not_pubed: bool,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]

--- a/crates/bin/main.rs
+++ b/crates/bin/main.rs
@@ -8,7 +8,7 @@ use time::macros::format_description;
 
 use crate::cli::{Cli, Commands};
 use crate::downloader::{download, generate_json};
-use crate::uploader::{append, login, renew, show, upload_by_command, upload_by_config};
+use crate::uploader::{append, list, login, renew, show, upload_by_command, upload_by_config};
 
 use clap::Parser;
 
@@ -70,6 +70,11 @@ async fn main() -> Result<()> {
             split_time,
         } => download(&url, output, split_size, split_time).await?,
         Commands::Server { bind, port } => server::run((&bind, port)).await?,
+        Commands::List {
+            is_pubing,
+            pubed,
+            not_pubed,
+        } => list(cli.user_cookie, is_pubing, pubed, not_pubed).await?,
     };
     Ok(())
 }

--- a/crates/bin/uploader.rs
+++ b/crates/bin/uploader.rs
@@ -137,6 +137,32 @@ pub async fn show(user_cookie: PathBuf, vid: Vid) -> Result<()> {
     Ok(())
 }
 
+pub async fn list(
+    user_cookie: PathBuf,
+    is_pubing: bool,
+    pubed: bool,
+    not_pubed: bool,
+) -> Result<()> {
+    let status = match (is_pubing, pubed, not_pubed) {
+        (true, false, false) => "is_pubing",
+        (false, true, false) => "pubed",
+        (false, false, true) => "not_pubed",
+        (false, false, false) => "is_pubing,pubed,not_pubed",
+        _ => {
+            tracing::warn!("选项互斥，默认列出所有状态的稿件");
+            "is_pubing,pubed,not_pubed"
+        }
+    };
+
+    let bilibili = login_by_cookies(user_cookie).await?;
+    bilibili
+        .all_archives(&status)
+        .await?
+        .iter()
+        .for_each(|arc| println!("{}", arc.to_string_pretty()));
+    Ok(())
+}
+
 async fn login_by_cookies(user_cookie: PathBuf) -> Result<BiliBili> {
     let result = credential::login_by_cookies(&user_cookie).await;
     Ok(if let Err(Kind::IO(_)) = result {


### PR DESCRIPTION
```
$ ./target/debug/biliup list -h
列出所有已上传的视频

Usage: biliup list [OPTIONS]

Options:
      --is-pubing  只包含进行中的视频
      --pubed      只包含已通过的视频
      --not-pubed  只包含未通过的视频
  -h, --help       Print help
```

Sample:
```
$ ./target/debug/biliup -u ***.json list
2023-07-15 23:44:56  INFO biliup::uploader::credential: 通过cookie登录
2023-07-15 23:44:57  INFO biliup::uploader::credential: 验证cookie
2023-07-15 23:44:57  INFO biliup::uploader::credential: 无需更新cookie
user: ***
BV***  2023.07.15-直播录像     审核中
BV***  2023.07.14-直播录像     开放浏览
...
BV***  2021.08.11-直播录像     开放浏览
BV***  2021.08.14-直播录像     已退回
...