### PR TITLE
日志相关修正

### DIFF
--- a/crates/biliup/src/client.rs
+++ b/crates/biliup/src/client.rs
@@ -15,8 +15,7 @@ pub struct StatelessClient {
 }
 
 impl StatelessClient {
-    pub fn new(mut headers: HeaderMap) -> Self {
-        headers.insert("Connection", header::HeaderValue::from_static("keep-alive"));
+    pub fn new(headers: HeaderMap) -> Self {
         let client = reqwest::Client::builder()
             .user_agent("Mozilla/5.0 (X11; Linux x86_64; rv:60.1) Gecko/20100101 Firefox/60.1")
             .default_headers(headers)

--- a/crates/stream-gears/src/lib.rs
+++ b/crates/stream-gears/src/lib.rs
@@ -43,12 +43,13 @@ fn download(
         let formatting_layer = tracing_subscriber::FmtSubscriber::builder()
             // will be written to stdout.
             // builds the subscriber.
-            .with_timer(local_time)
+            .with_timer(local_time.clone())
             .finish();
         let file_appender = tracing_appender::rolling::never("", "download.log");
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
         let file_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
+            .with_timer(local_time)
             .with_writer(non_blocking);
 
         let collector = formatting_layer.with(file_layer);
@@ -162,12 +163,13 @@ fn upload(
         let formatting_layer = tracing_subscriber::FmtSubscriber::builder()
             // will be written to stdout.
             // builds the subscriber.
-            .with_timer(local_time)
+            .with_timer(local_time.clone())
             .finish();
         let file_appender = tracing_appender::rolling::never("", "upload.log");
         let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
         let file_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
+            .with_timer(local_time)
             .with_writer(non_blocking);
 
         let collector = formatting_layer.with(file_layer);


### PR DESCRIPTION
1. 移除 client 里加 Connection: keep-alive 头的代码。hyper 会报 warning，意思大概为这个是自动处理的，不应该手动加。
2. 调整 stream-gears 文件日志的日期格式