### PR TITLE
为 stream-gears 添加 login_by_web_cookies/qrcode 的 API

### DIFF
--- a/crates/stream-gears/src/lib.rs
+++ b/crates/stream-gears/src/lib.rs
@@ -128,6 +128,30 @@ fn login_by_qrcode(ret: String) -> PyResult<bool> {
         ))),
     }
 }
+#[pyfunction]
+fn login_by_web_cookies(sess_data: String, bili_jct: String) -> PyResult<bool> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(async { login::login_by_web_cookies(&sess_data, &bili_jct).await });
+    match result {
+        Ok(_) => Ok(true),
+        Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "{}",
+            err
+        ))),
+    }
+}
+#[pyfunction]
+fn login_by_web_qrcode(sess_data: String, dede_user_id: String) -> PyResult<bool> {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(async { login::login_by_web_qrcode(&sess_data, &dede_user_id).await });
+    match result {
+        Ok(_) => Ok(true),
+        Err(err) => Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "{}",
+            err
+        ))),
+    }
+}
 
 #[pyfunction]
 fn upload(
@@ -220,6 +244,8 @@ fn stream_gears(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(login_by_qrcode, m)?)?;
     m.add_function(wrap_pyfunction!(get_qrcode, m)?)?;
     m.add_function(wrap_pyfunction!(login_by_sms, m)?)?;
+    m.add_function(wrap_pyfunction!(login_by_web_cookies, m)?)?;
+    m.add_function(wrap_pyfunction!(login_by_web_qrcode, m)?)?;
     m.add_class::<UploadLine>()?;
     Ok(())
 }

--- a/crates/stream-gears/src/login.rs
+++ b/crates/stream-gears/src/login.rs
@@ -29,3 +29,21 @@ pub async fn login_by_qrcode(res: serde_json::Value) -> Result<bool> {
     serde_json::to_writer_pretty(&file, &info)?;
     Ok(true)
 }
+
+pub async fn login_by_web_cookies(sess_data: &str, bili_jct: &str) -> Result<bool> {
+    let info = Credential::new()
+        .login_by_web_cookies(sess_data, bili_jct)
+        .await?;
+    let file = std::fs::File::create("cookies.json")?;
+    serde_json::to_writer_pretty(&file, &info)?;
+    Ok(true)
+}
+
+pub async fn login_by_web_qrcode(sess_data: &str, dede_user_id: &str) -> Result<bool> {
+    let info = Credential::new()
+        .login_by_web_qrcode(sess_data, dede_user_id)
+        .await?;
+    let file = std::fs::File::create("cookies.json")?;
+    serde_json::to_writer_pretty(&file, &info)?;
+    Ok(true)
+}


### PR DESCRIPTION
可能会根据 stream-gears 的需求陆续暴露更多 rs 这边的 API，先把我觉得会用到并且可测试的加上。