### PR TITLE
支持短信登录中的滑动验证

### DIFF
--- a/crates/biliup/src/client.rs
+++ b/crates/biliup/src/client.rs
@@ -1,4 +1,5 @@
 use crate::retry;
+use rand::Rng;
 use reqwest::header::HeaderMap;
 use reqwest::{header, Response};
 use reqwest_cookie_store::CookieStoreMutex;
@@ -59,6 +60,7 @@ impl StatelessClient {
 pub struct StatefulClient {
     pub client: reqwest::Client,
     pub cookie_store: Arc<CookieStoreMutex>,
+    pub buvid: String,
 }
 
 impl StatefulClient {
@@ -77,6 +79,7 @@ impl StatefulClient {
                 .build()
                 .unwrap(),
             cookie_store,
+            buvid: generate_buvid(),
         }
     }
 }
@@ -85,4 +88,24 @@ impl Default for StatelessClient {
     fn default() -> Self {
         Self::new(header::HeaderMap::new())
     }
+}
+
+// ref: https://github.com/SocialSisterYi/bilibili-API-collect
+fn generate_buvid() -> String {
+    let mut rng = rand::thread_rng();
+
+    let dummy_md5 = (0..32).map(|_| rng.gen_range(0..0xf)).collect::<Vec<u8>>();
+    let prefix = [2, 12, 22].map(|i| dummy_md5[i]);
+
+    let hash_string = [prefix.as_slice(), dummy_md5.as_slice()]
+        .map(|array| {
+            array
+                .iter()
+                .map(|n| format!("{n:X}"))
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .join("");
+
+    format!("Y{hash_string}")
 }

--- a/crates/biliup/src/error.rs
+++ b/crates/biliup/src/error.rs
@@ -35,6 +35,9 @@ pub enum Kind {
     // source and Display delegate to anyhow::Error
     #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
+
+    #[error("need recaptcha")]
+    NeedRecaptcha(String),
 }
 
 impl From<&str> for Kind {

--- a/crates/bin/uploader.rs
+++ b/crates/bin/uploader.rs
@@ -271,7 +271,22 @@ pub async fn login_by_sms(credential: Credential) -> Result<LoginInfo> {
     let phone: u64 = Input::with_theme(&ColorfulTheme::default())
         .with_prompt("请输入手机号")
         .interact_text()?;
-    let res = credential.send_sms(phone, country_code).await?;
+    let res = credential
+        .send_sms_handle_recaptcha(phone, country_code, |url| async move {
+            println!("{url}");
+            println!("请复制此链接至浏览器打开并启动开发者工具，完成滑动验证后查看网络请求");
+
+            let challenge: String = Input::with_theme(&ColorfulTheme::default())
+                .with_prompt("请输入get.php响应中的challenge值")
+                .interact_text()?;
+
+            let valiate: String = Input::with_theme(&ColorfulTheme::default())
+                .with_prompt("请输入ajax.php响应中的validate值")
+                .interact_text()?;
+
+            Ok((challenge, valiate))
+        })
+        .await?;
     let input: u32 = Input::with_theme(&ColorfulTheme::default())
         .with_prompt("请输入验证码")
         .interact_text()?;


### PR DESCRIPTION
添加了支持验证码的短信登录 API。用户可以自己在浏览器内完成滑动验证后输入验证结果，并通过回调继续登录。目前只在 biliup 命令行工具里添加此功能，stream_gears 应该也可以用类似的方法。