### PR TITLE
修复 CLI 缺少 dialoguer::Error 报错

### DIFF
--- a/crates/biliup/src/error.rs
+++ b/crates/biliup/src/error.rs
@@ -10,6 +10,9 @@ pub enum Kind {
     Custom(String),
 
     #[error(transparent)]
+    Dialoguer(#[from] dialoguer::Error),
+
+    #[error(transparent)]
     IO(#[from] std::io::Error),
 
     #[error(transparent)]


### PR DESCRIPTION
项目引用的 dialoguer 库在 aa3e7a3bc02738dae43a29ff6d34b51f5be52535 后添加了 Error 类型，造成 CLI 编译失败。CI 中只编译了 Lib 部分所以没有发现。