### PR TITLE
导出账号登录和B站API相关的模块

### DIFF
--- a/crates/biliup/src/lib.rs
+++ b/crates/biliup/src/lib.rs
@@ -13,6 +13,9 @@ pub mod error;
 pub mod server;
 pub mod uploader;
 
+pub use uploader::bilibili;
+pub use uploader::credential;
+
 pub async fn retry<F, Fut, O, E: std::fmt::Display>(mut f: F) -> Result<O, E>
 where
     F: FnMut() -> Fut,


### PR DESCRIPTION
`uploader::bilibili` 和 `uploader::credential` 可以作为库提供的模块使用，方便登录等操作。