### PR TITLE
修复二维码表单的字段顺序

### DIFF
--- a/crates/biliup/src/uploader/credential.rs
+++ b/crates/biliup/src/uploader/credential.rs
@@ -405,8 +405,8 @@ impl Credential {
     pub async fn login_by_qrcode(&self, value: Value) -> Result<LoginInfo> {
         let mut form = json!({
             "appkey": AppKeyStore::BiliTV.app_key(),
-            "local_id": "0",
             "auth_code": value["data"]["auth_code"],
+            "local_id": "0",
             "ts": SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs()
         });
         let urlencoded = serde_urlencoded::to_string(&form)?;


### PR DESCRIPTION
API 签名要求字段名要按字典序排列。本 PR 修复二维码验证里 `auth_code` 和 `local_id` 的顺序。