### PR TITLE
Add 支持自定义的提交参数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 *.part
 data.db*
 *.whl
+.vscode
+*.json
+*.yaml

--- a/crates/biliup/src/uploader/bilibili.rs
+++ b/crates/biliup/src/uploader/bilibili.rs
@@ -129,7 +129,7 @@ pub struct Studio {
     // #[serde(default)]
     // pub submit_by_app: bool,
     /// 自定义提交参数
-    #[clap(long = "extra_fields", value_parser = parse_extra_fields)]
+    #[clap(long, value_parser = parse_extra_fields)]
     #[serde(flatten)]
     pub extra_fields: Option<HashMap<String, Value>>,
 }

--- a/crates/biliup/src/uploader/bilibili.rs
+++ b/crates/biliup/src/uploader/bilibili.rs
@@ -3,6 +3,8 @@ use crate::uploader::credential::LoginInfo;
 use serde::ser::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
+
 use std::fmt::{Display, Formatter};
 use std::num::ParseIntError;
 use std::str::FromStr;
@@ -123,10 +125,17 @@ pub struct Studio {
     #[clap(long)]
     #[serde(default)]
     pub up_close_danmu: bool,
-
     // #[clap(long)]
     // #[serde(default)]
     // pub submit_by_app: bool,
+    /// 自定义提交参数
+    #[clap(long = "extra_fields", value_parser = parse_extra_fields)]
+    #[serde(flatten)]
+    pub extra_fields: Option<HashMap<String, Value>>,
+}
+
+fn parse_extra_fields(s: &str) -> std::result::Result<HashMap<String, Value>, String> {
+    serde_json::from_str(s).map_err(|e| e.to_string())
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -201,8 +210,7 @@ impl FromStr for Vid {
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let s = s.trim();
         if s.len() < 3 {
-            return s.parse::<u64>()
-                    .map(Vid::Aid);
+            return s.parse::<u64>().map(Vid::Aid);
         }
         match &s[..2] {
             "BV" => Ok(Vid::Bvid(s.to_string())),
@@ -228,27 +236,27 @@ pub struct BiliBili {
 
 impl BiliBili {
     pub async fn submit(&self, studio: &Studio) -> Result<ResponseData> {
-            let ret: ResponseData = reqwest::Client::builder()
-                .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/63.0.3239.108")
-                .timeout(Duration::new(60, 0))
-                .build()?
-                .post(format!(
-                    "http://member.bilibili.com/x/vu/client/add?access_key={}",
-                    self.login_info.token_info.access_token
-                ))
-                .json(studio)
-                .send()
-                .await?
-                .json()
-                .await?;
-            info!("{:?}", ret);
-            if ret.code == 0 {
-                info!("投稿成功");
-                Ok(ret)
-            } else {
-                Err(Kind::Custom(format!("{:?}", ret)))
-            }
+        let ret: ResponseData = reqwest::Client::builder()
+            .user_agent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/63.0.3239.108")
+            .timeout(Duration::new(60, 0))
+            .build()?
+            .post(format!(
+                "http://member.bilibili.com/x/vu/client/add?access_key={}",
+                self.login_info.token_info.access_token
+            ))
+            .json(studio)
+            .send()
+            .await?
+            .json()
+            .await?;
+        info!("{:?}", ret);
+        if ret.code == 0 {
+            info!("投稿成功");
+            Ok(ret)
+        } else {
+            Err(Kind::Custom(format!("{:?}", ret)))
         }
+    }
 
     pub async fn submit_by_app(&self, studio: &Studio) -> Result<ResponseData> {
         let payload = {
@@ -267,7 +275,10 @@ impl BiliBili {
             });
 
             let urlencoded = serde_urlencoded::to_string(&payload)?;
-            let sign = crate::credential::Credential::sign(&urlencoded, crate::credential::AppKeyStore::BiliTV.appsec());
+            let sign = crate::credential::Credential::sign(
+                &urlencoded,
+                crate::credential::AppKeyStore::BiliTV.appsec(),
+            );
             payload["sign"] = Value::from(sign);
             payload
         };

--- a/crates/stream-gears/src/uploader.rs
+++ b/crates/stream-gears/src/uploader.rs
@@ -9,6 +9,7 @@ use futures::StreamExt;
 use pyo3::prelude::*;
 use pyo3::pyclass;
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
 use tracing::info;
@@ -28,7 +29,7 @@ pub enum UploadLine {
     Tx,
     Txa,
     Bda,
-    Alia
+    Alia,
 }
 
 #[derive(FromPyObject)]
@@ -60,13 +61,15 @@ pub struct StudioPre {
     lossless_music: u8,
     no_reprint: u8,
     open_elec: u8,
-    #[builder(default=false)]
+    #[builder(default = false)]
     up_close_reply: bool,
-    #[builder(default=false)]
+    #[builder(default = false)]
     up_selection_reply: bool,
-    #[builder(default=false)]
+    #[builder(default = false)]
     up_close_danmu: bool,
     desc_v2_credit: Vec<PyCredit>,
+    #[builder(default)]
+    extra_fields: Option<HashMap<String, serde_json::Value>>,
 }
 
 pub async fn upload(studio_pre: StudioPre) -> Result<ResponseData> {
@@ -93,6 +96,7 @@ pub async fn upload(studio_pre: StudioPre) -> Result<ResponseData> {
         no_reprint,
         open_elec,
         desc_v2_credit,
+        extra_fields,
         ..
     } = studio_pre;
 
@@ -173,6 +177,7 @@ pub async fn upload(studio_pre: StudioPre) -> Result<ResponseData> {
         .no_reprint(no_reprint)
         .open_elec(open_elec)
         .desc_v2(Some(desc_v2))
+        .extra_fields(extra_fields)
         .build();
 
     if !studio.cover.is_empty() {
@@ -216,6 +221,7 @@ pub async fn upload_by_app(studio_pre: StudioPre) -> Result<ResponseData> {
         up_selection_reply,
         up_close_danmu,
         desc_v2_credit,
+        extra_fields,
     } = studio_pre;
 
     let bilibili = login_by_cookies(&cookie_file).await;
@@ -298,6 +304,7 @@ pub async fn upload_by_app(studio_pre: StudioPre) -> Result<ResponseData> {
         .up_selection_reply(up_selection_reply)
         .up_close_danmu(up_close_danmu)
         .desc_v2(Some(desc_v2))
+        .extra_fields(extra_fields)
         .build();
 
     if !studio.cover.is_empty() {


### PR DESCRIPTION
可以在命令行传递参数 ` --extra-fields '<json 字符串>' ` 实现添加自定义提交参数 
例如B站最近添加了 `仅自己可见投稿` 选项,可以使用以下命令行投稿
```
biliup upload --tid 21 --tag "xxx" --cover ./xxx.jpg --extra-fields '{"is_only_self":1}'  ./xxx.mp4 
```
`{"is_only_self": 1}` 为抓包获取的参数