### PR TITLE
feat: expose max retry time to upload and append subcommand

### DIFF
--- a/crates/biliup-cli/src/cli.rs
+++ b/crates/biliup-cli/src/cli.rs
@@ -55,6 +55,10 @@ pub enum Commands {
         #[arg(long, default_value = "3")]
         limit: usize,
 
+        /// 最大重试次数
+        #[arg(long, default_value = "3")]
+        retry: u32,
+
         #[command(flatten)]
         studio: Studio,
         // #[arg(required = false, last = true, default_value = "client")]
@@ -78,6 +82,10 @@ pub enum Commands {
         /// 单视频文件最大并发数
         #[arg(long, default_value = "3")]
         limit: usize,
+
+        /// 最大重试次数
+        #[arg(long, default_value = "3")]
+        retry: u32,
 
         #[command(flatten)]
         studio: Studio,

--- a/crates/biliup-cli/src/main.rs
+++ b/crates/biliup-cli/src/main.rs
@@ -53,6 +53,7 @@ async fn main() -> Result<()> {
             config: None,
             line,
             limit,
+            retry,
             studio,
             submit,
         } => {
@@ -62,6 +63,7 @@ async fn main() -> Result<()> {
                 video_path,
                 line,
                 limit,
+                retry,
                 submit,
                 cli.proxy.as_deref(),
             )
@@ -77,6 +79,7 @@ async fn main() -> Result<()> {
             vid,
             line,
             limit,
+            retry,
             studio: _,
         } => {
             append(
@@ -85,6 +88,7 @@ async fn main() -> Result<()> {
                 video_path,
                 line,
                 limit,
+                retry,
                 cli.proxy.as_deref(),
             )
             .await?

--- a/crates/biliup/src/client.rs
+++ b/crates/biliup/src/client.rs
@@ -38,18 +38,21 @@ impl StatelessClient {
     }
 
     pub async fn retryable(&self, url: &str) -> reqwest::Result<Response> {
-        let resp = retry(|| {
-            self.client
-                .get(url)
-                .headers(self.headers.clone())
-                // .timeout(Duration::MAX)
-                // .header(ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-                // .header(ACCEPT_ENCODING, "gzip, deflate")
-                // .header(ACCEPT_LANGUAGE, "zh-CN,zh;q=0.8,en-US;q=0.5,en;q=0.3")
-                // .header(USER_AGENT, "Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0 Iceweasel/38.2.1")
-                // .headers(headers.clone())
-                .send()
-        })
+        let resp = retry(
+            || {
+                self.client
+                    .get(url)
+                    .headers(self.headers.clone())
+                    // .timeout(Duration::MAX)
+                    // .header(ACCEPT, "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+                    // .header(ACCEPT_ENCODING, "gzip, deflate")
+                    // .header(ACCEPT_LANGUAGE, "zh-CN,zh;q=0.8,en-US;q=0.5,en;q=0.3")
+                    // .header(USER_AGENT, "Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0 Iceweasel/38.2.1")
+                    // .headers(headers.clone())
+                    .send()
+            },
+            3,
+        )
         .await?;
         resp.error_for_status_ref()?;
         Ok(resp)

--- a/crates/biliup/src/lib.rs
+++ b/crates/biliup/src/lib.rs
@@ -12,12 +12,12 @@ pub mod uploader;
 pub use uploader::bilibili;
 pub use uploader::credential;
 
-pub async fn retry<F, Fut, O, E: std::fmt::Display>(mut f: F) -> Result<O, E>
+pub async fn retry<F, Fut, O, E: std::fmt::Display>(mut f: F, max_retries: u32) -> Result<O, E>
 where
     F: FnMut() -> Fut,
     Fut: Future<Output = Result<O, E>>,
 {
-    let mut retries = 3;
+    let mut retries = max_retries;
     let mut wait = 1;
     let mut jittered_wait_for;
     loop {
@@ -31,7 +31,7 @@ where
                 jittered_wait_for = f64::min(jitter_factor + (wait as f64), 64.);
                 info!(
                     "Retry attempt #{}. Sleeping {:?} before the next attempt. {e}",
-                    3 - retries,
+                    max_retries - retries,
                     jittered_wait_for
                 );
                 sleep(Duration::from_secs_f64(jittered_wait_for)).await;

--- a/crates/biliup/src/uploader/bilibili.rs
+++ b/crates/biliup/src/uploader/bilibili.rs
@@ -1,9 +1,9 @@
+use crate::ReqwestClientBuilderExt;
 use crate::error::{Kind, Result};
 use crate::uploader::credential::LoginInfo;
-use crate::ReqwestClientBuilderExt;
 use serde::ser::Error;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::collections::HashMap;
 
 use std::fmt::{Display, Formatter};
@@ -496,7 +496,12 @@ impl BiliBili {
         }
     }
 
-    async fn recent_archives_data(&self, status: &str, from_page: u32, max_pages: Option<u32>) -> Result<Vec<Value>> {
+    async fn recent_archives_data(
+        &self,
+        status: &str,
+        from_page: u32,
+        max_pages: Option<u32>,
+    ) -> Result<Vec<Value>> {
         let mut first_page = self.archives(status, from_page).await?;
 
         let (page_size, count) = {
@@ -536,7 +541,12 @@ impl BiliBili {
     }
 
     /// 获取页数范围内的稿件
-    pub async fn recent_archives(&self, status: &str, from_page: u32, max_pages: Option<u32>) -> Result<Vec<Archive>> {
+    pub async fn recent_archives(
+        &self,
+        status: &str,
+        from_page: u32,
+        max_pages: Option<u32>,
+    ) -> Result<Vec<Archive>> {
         let studios = self
             .recent_archives_data(status, from_page, max_pages)
             .await?

--- a/crates/biliup/src/uploader/line.rs
+++ b/crates/biliup/src/uploader/line.rs
@@ -32,6 +32,7 @@ impl Parcel {
         client: StatelessClient,
         limit: usize,
         progress: F,
+        retry: u32,
     ) -> Result<Video>
     where
         F: FnOnce(VideoStream) -> S,
@@ -68,7 +69,7 @@ impl Parcel {
             Bucket::Upos(bucket) => {
                 // let bucket: crate::uploader::upos::Bucket = self.pre_upload(client).await?;
                 let chunk_size = bucket.chunk_size;
-                let upos = Upos::from(client, bucket).await?;
+                let upos = Upos::from(client, bucket, retry).await?;
                 let mut parts = Vec::new();
                 let stream = upos
                     .upload_stream(

--- a/crates/stream-gears/src/uploader.rs
+++ b/crates/stream-gears/src/uploader.rs
@@ -132,13 +132,18 @@ pub async fn upload(studio_pre: StudioPre, proxy: Option<&str>) -> Result<Respon
         let instant = Instant::now();
 
         let video = uploader
-            .upload(client.clone(), limit, |vs| {
-                vs.map(|vs| {
-                    let chunk = vs?;
-                    let len = chunk.len();
-                    Ok((chunk, len))
-                })
-            })
+            .upload(
+                client.clone(),
+                limit,
+                |vs| {
+                    vs.map(|vs| {
+                        let chunk = vs?;
+                        let len = chunk.len();
+                        Ok((chunk, len))
+                    })
+                },
+                3,
+            )
             .await?;
         let t = instant.elapsed().as_millis();
         info!(
@@ -256,13 +261,18 @@ pub async fn upload_by_app(studio_pre: StudioPre, proxy: Option<&str>) -> Result
         let instant = Instant::now();
 
         let video = uploader
-            .upload(client.clone(), limit, |vs| {
-                vs.map(|vs| {
-                    let chunk = vs?;
-                    let len = chunk.len();
-                    Ok((chunk, len))
-                })
-            })
+            .upload(
+                client.clone(),
+                limit,
+                |vs| {
+                    vs.map(|vs| {
+                        let chunk = vs?;
+                        let len = chunk.len();
+                        Ok((chunk, len))
+                    })
+                },
+                3,
+            )
             .await?;
         let t = instant.elapsed().as_millis();
         info!(


### PR DESCRIPTION
<img width="730" height="44" alt="image" src="https://github.com/user-attachments/assets/ea8e22ff-6f92-4b23-a9cb-f899af7592cb" />

In some unstable network environments, it's very easy to exceed the default 3 retries limit and abort the entire upload procedure. Considering this tool doesn't support failure recovery, each time it aborts will need a re-upload from the very beginning. So I'd like it to keep retrying with a larger retry limit instead of aborting.

This patch adds the `--retry` param to `upload` and `append` subcommands, with a default value of 3